### PR TITLE
ci: nettoyage scans/report (doublon ecoindex, set-output, Node 24)

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Website
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/scans.yml
+++ b/.github/workflows/scans.yml
@@ -46,7 +46,7 @@ jobs:
       sites: ${{ steps.init.outputs.sites }}
       config: ${{ steps.init.outputs.config }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - id: init
         uses: "SocialGouv/dashlord-actions/init@v1"
         with:
@@ -68,14 +68,14 @@ jobs:
       matrix:
         sites: ${{ fromJson(needs.init.outputs.sites) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
 
       - run: |
           mkdir scans
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -127,15 +127,6 @@ jobs:
         with:
           url: ${{ matrix.sites.url }}
           output: scans/declaration-a11y.json
-
-      - name: eco-index
-        continue-on-error: true
-        timeout-minutes: 10
-        uses: "socialgouv/dashlord-actions/ecoindex@v1"
-        if: ${{ matrix.sites.tools.ecoindex }}
-        with:
-          url: ${{ matrix.sites.url }}
-          output: scans/ecoindex.json
 
       - name: Déclaration RGPD
         timeout-minutes: 10
@@ -249,7 +240,7 @@ jobs:
         id: hostname
         run: |
           HOSTNAME=$(echo "${{ matrix.sites.url }}" | sed -e 's/[^/]*\/\/\([^@]*@\)\?\([^:/]*\).*/\2/')
-          echo "::set-output name=value::$HOSTNAME"
+          echo "value=$HOSTNAME" >> "$GITHUB_OUTPUT"
 
       - name: testssl.sh scan
         if: ${{ matrix.sites.tools.testssl }}


### PR DESCRIPTION
## Contexte

Audit des logs de la CI. Le workflow `DashLord scans` est `continue-on-error` au niveau job : il passe au vert alors que plusieurs étapes échouent silencieusement. Cette PR corrige les problèmes qui relèvent de nos workflows.

## Correctifs

- **Doublon `eco-index`** : l'étape était déclarée **deux fois**, la 2ᵉ provoquait `docker: Conflict. The container name "/ecoindex" is already in use` (exit 125). La 2ᵉ déclaration est supprimée.
- **`set-output` déprécié** : l'étape *Extract hostname* utilise désormais `$GITHUB_OUTPUT`.
- **Préparation Node 24** (échéance GitHub du **16 juin 2026**, bascule forcée des actions Node 20 → Node 24) : `actions/checkout@v4 → @v5` et `actions/cache@v4 → @v5` sur `scans.yml` et `report.yml` (seules actions GitHub officielles directement référencées ; `@v5` tourne en Node 24).

## Hors périmètre (à traiter séparément)

- `UPDOWNIO_API_KEY` absent/invalide → `401 Unauthorized` sur l'étape updown.io (secret à configurer côté repo).
- `SocialGouv/httpobs-action@master` casse sur Node 16 (`node-releases` exige ≥18) — action externe.
- `swinton/screenshot-website@v1.x` : inputs `type`/`scaleFactor` invalides + timeout — action externe.
- Crash du build `report` sur la phase beta.gouv `consolidation` : corrigé via SocialGouv/dashlord-actions#366 (en attente de merge + retag `v1`).